### PR TITLE
fix: allow tag query param from studio

### DIFF
--- a/src/controllers/resolve.js
+++ b/src/controllers/resolve.js
@@ -31,7 +31,8 @@ router.get(
             .valid(extractorNames)
             .allow('*')
         )
-        .default(['meta', 'openGraph'])
+        .default(['meta', 'openGraph']),
+      tag: Joi.string()
     })
   }),
   resolve


### PR DESCRIPTION
This fixes the 400 issue when the URL Metadata Input in the Sanity Studio makes a request with a `tag` query param.